### PR TITLE
Add CSV Generation from Server Response and Dual File Saving Logic

### DIFF
--- a/lib/modules/echo_parse/blocs/echo_parse_event.dart
+++ b/lib/modules/echo_parse/blocs/echo_parse_event.dart
@@ -7,6 +7,8 @@ class EchoParseChooseAudiogramFileEvent extends EchoParseEvent {}
 
 class EchoParseUploadAudiogramFileToServerEvent extends EchoParseEvent {}
 
+class EchoParseSaveProcessedCsvEvent extends EchoParseEvent {}
+
 class EchoParseReceivedServerResponseEvent extends EchoParseEvent {
   final int statusCode;
   final Map<String, dynamic> audiogramData;

--- a/lib/modules/echo_parse/screens/echo_parse_upload_done_page/echo_parse_upload_done_page.dart
+++ b/lib/modules/echo_parse/screens/echo_parse_upload_done_page/echo_parse_upload_done_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:hear_mate_app/modules/echo_parse/blocs/echo_parse_bloc.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
 
 class EchoParseUploadDoneScreen extends StatelessWidget {
   const EchoParseUploadDoneScreen({super.key});
@@ -224,6 +227,7 @@ class EchoParseUploadDoneScreen extends StatelessWidget {
                               elevation: 10,
                             ),
                             onPressed: () {
+                              context.read<EchoParseBloc>().add(EchoParseSaveProcessedCsvEvent());
                               Navigator.pushNamed(context, "/echo_parse/collection");
                             },
                             child: Center(child:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
 
   hm_locale:
     path: ./packages/hm_locale
+  fpdart: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR implements the functionality to transform server-returned audiogram data into a valid CSV format and save it in two locations:

- Internal app storage (for reuse or caching),

- User-visible directory (Downloads/Documents on mobile, user-selected location on desktop).