### PR TITLE
Pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: dart-format
+        name: Check Dart Format
+        entry: bash hooks/pre-commit
+        language: system
+        types: [dart]

--- a/README.md
+++ b/README.md
@@ -46,19 +46,24 @@ We welcome contributions from the community! To contribute to this project, plea
    git clone https://github.com/your-username/repo.git
    cd repo
    ```
-3. **Create a new branch** for your feature or bugfix:
+3. **Install pre-commit hook** on your local machine:
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+4. **Create a new branch** for your feature or bugfix:
    ```bash
    git checkout -b feature-or-bugfix-name
    ```
-4. **Make your changes** and commit them with a clear message:
+5. **Make your changes** and commit them with a clear message:
    ```bash
    git commit -m "Description of the changes"
    ```
-5. **Push your changes** to your forked repository:
+6. **Push your changes** to your forked repository:
    ```bash
    git push origin feature-or-bugfix-name
    ```
-6. **Create a pull request** on the original repository and describe your changes.
+7. **Create a pull request** on the original repository and describe your changes.
 
 ### Reporting Issues
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo -e "Checking Dart code formatting...\n"
+
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.dart$')
+
+HAS_ERROR=0
+
+for file in $FILES; do
+	if [ -f "$file" ]; then
+		OUTPUT=$(dart format --set-exit-if-changed "$file" 2>&1)
+		if [ $? -ne 0 ]; then
+			echo -e "$file (formatted)."
+		else
+			echo "$file (not changed)."  
+		fi
+	fi
+done
+
+echo -e "\nAll Dart files are now properly formatted."
+echo -e "\033[31mAdd changed files to staging area to commit the changes.\033[0m"
+exit 0


### PR DESCRIPTION
Added a pre-commit hook that checks Dart code formatting before each commit.  
After a simple setup, it helps ensure consistent code style across the project.

Just install python package pre-commit via pip, install it via `pre-commit install` and from this moment you should be able to use pre-commit.