### PR TITLE
Minor fixes

### DIFF
--- a/lib/modules/hearing_test/blocs/hearing_test/hearing_test_event.dart
+++ b/lib/modules/hearing_test/blocs/hearing_test/hearing_test_event.dart
@@ -5,6 +5,8 @@ sealed class HearingTestEvent {}
 
 class HearingTestStartTest extends HearingTestEvent {}
 
+class HearingTestContinueTest extends HearingTestEvent {}
+
 class HearingTestButtonPressed extends HearingTestEvent {}
 
 class HearingTestButtonReleased extends HearingTestEvent {}

--- a/lib/modules/hearing_test/blocs/hearing_test/hearing_test_event.dart
+++ b/lib/modules/hearing_test/blocs/hearing_test/hearing_test_event.dart
@@ -5,8 +5,6 @@ sealed class HearingTestEvent {}
 
 class HearingTestStartTest extends HearingTestEvent {}
 
-class HearingTestContinueTest extends HearingTestEvent {}
-
 class HearingTestButtonPressed extends HearingTestEvent {}
 
 class HearingTestButtonReleased extends HearingTestEvent {}

--- a/lib/modules/hearing_test/blocs/hearing_test/hearing_test_state.dart
+++ b/lib/modules/hearing_test/blocs/hearing_test/hearing_test_state.dart
@@ -3,10 +3,12 @@ part of 'hearing_test_bloc.dart';
 class HearingTestState {
   final bool isButtonPressed;
   final bool wasSoundHeard;
-  final bool currentEar; // true is left, false is right
-  final bool isTestCanceled;
+  final bool isTestCompleted;
+
   final int currentFrequencyIndex;
   final double currentDBLevel;
+  final HearingTestEar currentEar;
+
   final Map<double, int> dbLevelToHearCountMap;
   final HearingTestResult results;
   final bool resultSaved;
@@ -14,8 +16,8 @@ class HearingTestState {
   HearingTestState({
     this.isButtonPressed = false,
     this.wasSoundHeard = false,
-    this.currentEar = true,
-    this.isTestCanceled = false,
+    this.currentEar = HearingTestEar.LEFT,
+    this.isTestCompleted = false,
     this.currentFrequencyIndex = 0,
     this.currentDBLevel = 60,
     this.dbLevelToHearCountMap = const {},
@@ -38,8 +40,8 @@ class HearingTestState {
   HearingTestState copyWith({
     bool? isButtonPressed,
     bool? wasSoundHeard,
-    bool? currentEar,
-    bool? isTestCanceled,
+    HearingTestEar? currentEar,
+    bool? isTestCompleted,
     int? currentFrequencyIndex,
     double? currentDBLevel,
     Map<double, int>? dbLevelToHearCountMap,
@@ -50,7 +52,7 @@ class HearingTestState {
       isButtonPressed: isButtonPressed ?? this.isButtonPressed,
       wasSoundHeard: wasSoundHeard ?? this.wasSoundHeard,
       currentEar: currentEar ?? this.currentEar,
-      isTestCanceled: isTestCanceled ?? this.isTestCanceled,
+      isTestCompleted: isTestCompleted ?? this.isTestCompleted,
       currentFrequencyIndex:
           currentFrequencyIndex ?? this.currentFrequencyIndex,
       currentDBLevel: currentDBLevel ?? this.currentDBLevel,

--- a/lib/modules/hearing_test/blocs/hearing_test/hearing_test_state.dart
+++ b/lib/modules/hearing_test/blocs/hearing_test/hearing_test_state.dart
@@ -3,7 +3,7 @@ part of 'hearing_test_bloc.dart';
 class HearingTestState {
   final bool isButtonPressed;
   final bool wasSoundHeard;
-  final bool currentEar; // false is left, true is right
+  final bool currentEar; // true is left, false is right
   final bool isTestCanceled;
   final int currentFrequencyIndex;
   final double currentDBLevel;
@@ -14,7 +14,7 @@ class HearingTestState {
   HearingTestState({
     this.isButtonPressed = false,
     this.wasSoundHeard = false,
-    this.currentEar = false,
+    this.currentEar = true,
     this.isTestCanceled = false,
     this.currentFrequencyIndex = 0,
     this.currentDBLevel = 60,

--- a/lib/modules/hearing_test/repositories/hearing_test_sounds_player_repository.dart
+++ b/lib/modules/hearing_test/repositories/hearing_test_sounds_player_repository.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:hear_mate_app/modules/hearing_test/utils/constants.dart'
     as HearingTestConstants;
+import 'package:hear_mate_app/modules/hearing_test/utils/hearing_test_ear.dart';
 import 'package:hear_mate_app/utils/logger.dart';
 
 class HearingTestSoundsPlayerRepository {
@@ -29,15 +30,15 @@ class HearingTestSoundsPlayerRepository {
     await _audioPlayer.setReleaseMode(ReleaseMode.stop);
   }
 
-  Future<void> playSound(
-    int frequency, {
+  Future<void> playSound({
+    required int frequency,
     required double decibels,
-    required bool leftEarOnly,
+    required HearingTestEar ear,
   }) async {
     if (_soundAssets.containsKey(frequency)) {
       try {
         String assetPath =
-            leftEarOnly
+            ear == HearingTestEar.LEFT
                 ? _soundAssets[frequency]!['left']!
                 : _soundAssets[frequency]!['right']!;
 
@@ -124,7 +125,7 @@ class HearingTestSoundsPlayerRepository {
   }
 
   double _headphoneCorrection(double dBSPL, int frequency) {
-      const Map<int, double> correctionReference = {
+    const Map<int, double> correctionReference = {
       125: -10.0,
       250: -8.0,
       500: -6.5,

--- a/lib/modules/hearing_test/screens/hearing_test_history_results/hearing_test_history_results.dart
+++ b/lib/modules/hearing_test/screens/hearing_test_history_results/hearing_test_history_results.dart
@@ -5,9 +5,21 @@ import 'package:hear_mate_app/widgets/hm_app_bar.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:hear_mate_app/modules/hearing_test/widgets/audiogram_chart.dart';
 import 'package:hear_mate_app/modules/hearing_test/screens/hearing_test_history_results/alert_dialogs.dart';
+import 'package:hear_mate_app/modules/hearing_test/utils/hearing_test_utils.dart';
 
 // TODO:
 // - show trends what has happened with hearing over time / from last test
+
+List<String> remapDbValues(List<double?> values) {
+  if (values.length != 8) return [];
+  final mapping = getFrequencyMapping(values);
+  final List<String> mapped = [];
+  for (final entry in mapping) {
+    final dbValue = values[entry.key];
+    mapped.add(dbValue != null ? dbValue.toStringAsFixed(1) : '-');
+  }
+  return mapped;
+}
 
 class HearingTestHistoryResultsPage extends StatelessWidget {
   const HearingTestHistoryResultsPage({super.key});
@@ -49,8 +61,8 @@ class HearingTestHistoryResultsPage extends StatelessWidget {
                       title: Text(result.dateLabel),
                       subtitle: Text(
                         l10n.hearing_test_history_page_result_info(
-                          result.leftEarResults.map((e) => e ?? "-"),
-                          result.rightEarResults.map((e) => e ?? "-"),
+                          remapDbValues(result.leftEarResults),
+                          remapDbValues(result.rightEarResults),
                         ),
                       ),
                       trailing: IconButton(

--- a/lib/modules/hearing_test/screens/hearing_test_page/hearing_test_page.dart
+++ b/lib/modules/hearing_test/screens/hearing_test_page/hearing_test_page.dart
@@ -10,21 +10,26 @@ class HearingTestPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
-    
+
     return Scaffold(
       body: BlocConsumer<HearingTestBloc, HearingTestState>(
         listener: (context, state) {
-          if (state is HearingTestCompleted) {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder:
-                    (_) => BlocProvider.value(
-                      value: context.read<HearingTestBloc>(),
-                      child: HearingTestResultPage(),
-                    ),
-              ),
-            );
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder:
+                  (_) => BlocProvider.value(
+                    value: context.read<HearingTestBloc>(),
+                    child: HearingTestResultPage(),
+                  ),
+            ),
+          );
+        },
+        listenWhen: (previous, current) {
+          if (previous.isTestCompleted == false &&
+              current.isTestCompleted == true) {
+            return true;
           }
+          return false;
         },
         builder: (context, state) {
           return SafeArea(
@@ -102,16 +107,6 @@ class HearingTestPage extends StatelessWidget {
                     onPressed: () {
                       context.read<HearingTestBloc>().add(
                         HearingTestEndTestEarly(),
-                      );
-
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder:
-                              (_) => BlocProvider.value(
-                                value: context.read<HearingTestBloc>(),
-                                child: HearingTestResultPage(),
-                              ),
-                        ),
                       );
                     },
                     child: Text(

--- a/lib/modules/hearing_test/utils/hearing_test_ear.dart
+++ b/lib/modules/hearing_test/utils/hearing_test_ear.dart
@@ -1,0 +1,1 @@
+enum HearingTestEar { LEFT, RIGHT }

--- a/lib/modules/hearing_test/utils/hearing_test_utils.dart
+++ b/lib/modules/hearing_test/utils/hearing_test_utils.dart
@@ -1,0 +1,13 @@
+
+List<MapEntry<int, int>> getFrequencyMapping(List<double?> values) {
+  return [
+    MapEntry(7, 0),
+    MapEntry(6, 1),
+    MapEntry(5, 2),
+    // For 1000 Hz we always want to use the second value if available
+    values[4] != null ? MapEntry(4, 3) : MapEntry(0, 3),
+    MapEntry(1, 4),
+    MapEntry(2, 5),
+    MapEntry(3, 6),
+  ];
+}

--- a/lib/modules/hearing_test/widgets/audiogram_chart.dart
+++ b/lib/modules/hearing_test/widgets/audiogram_chart.dart
@@ -1,6 +1,7 @@
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:hear_mate_app/modules/hearing_test/utils/hearing_test_utils.dart';
 import 'package:hear_mate_app/modules/hearing_test/utils/constants.dart'
     as HearingTestConstants;
 
@@ -30,16 +31,7 @@ class AudiogramChart extends StatelessWidget {
 
   List<FlSpot> remapSpots(List<double?> values) {
     if (values.length != frequencyLabels.length + 1) return [];
-    final List<MapEntry<int, int>> mapping = [
-      MapEntry(7, 0),
-      MapEntry(6, 1),
-      MapEntry(5, 2),
-      // For 1000 Hz we always want to use the second value if available
-      values[4] != null ? MapEntry(4, 3) : MapEntry(0, 3),
-      MapEntry(1, 4),
-      MapEntry(2, 5),
-      MapEntry(3, 6),
-    ];
+    final mapping = getFrequencyMapping(values);
     final List<FlSpot> mapped = [];
     for (final entry in mapping) {
       final dbValue = values[entry.key];


### PR DESCRIPTION
This pull request intruduces fixes to the issues:

- Drawing the chart and ear order #64 
-- Corrected the logic for rendering the audiogram chart, ensuring both ears are visualized in the correct order.
<img width="1254" height="673" alt="Zrzut ekranu 2025-07-22 013534" src="https://github.com/user-attachments/assets/0055e23a-656b-46ee-a39b-1c555b6a51ec" />

- Number shuffle in the history page #63 
-- Fixed the remapping and display of hearing test results in the history page.
-- Ensures that results are shown in the intended frequency order, preventing mismatches or shuffled values.
<img width="1248" height="512" alt="image" src="https://github.com/user-attachments/assets/98083140-9b8b-4761-bfa1-6a9528b0a0e3" />
