### PR TITLE
Add disclaimer message before first hearing test

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -113,6 +113,8 @@
     "hearing_test_welcome_page_welcome": "Willkommen zum Hörtest",
     "hearing_test_welcome_page_description": "Dieses Modul testet dein Hörvermögen bei verschiedenen Frequenzen.",
     "hearing_test_welcome_page_start_hearing_test": "Test starten",
+    "hearing_test_welcome_page_disclaimer_title": "Haftungsausschluss",
+    "hearing_test_welcome_page_disclaimer": "Dies ist kein medizinisches Produkt. Es ist ausschließlich für die Verwendung mit Sony WH-1000XM5-Kopfhörern vorgesehen, mit eingeschaltetem Geräuschunterdrückung und maximaler Lautstärke, ohne Equalizer.",
 
     "hearing_test_delete_alert_title": "Ergebnis löschen",
     "hearing_test_delete_alert_message": "Möchten Sie dieses Ergebnis wirklich dauerhaft löschen? Diese Aktion kann nicht rückgängig gemacht werden.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -320,6 +320,9 @@
     "hearing_test_welcome_page_welcome": "Welcome to Hearing Test",
     "hearing_test_welcome_page_description": "This module will test your hearing ability across different frequencies.",
     "hearing_test_welcome_page_start_hearing_test": "Start Test",
+    "hearing_test_welcome_page_disclaimer_title": "Disclaimer",
+    "hearing_test_welcome_page_disclaimer": "This is not a medical grade product. It is intended to be used only with Sony WH-1000XM5 headphones, with noise cancelling turned on and volume set to maximum, equalizer shall not be used.",
+
 
     "@hearing_test_welcome_page_title": {
         "description": "Title displayed on the welcome page of the hearing test module."
@@ -333,6 +336,13 @@
     "@hearing_test_welcome_page_start_hearing_test": {
         "description": "Label for the button to start the hearing test."
     },
+     "@hearing_test_welcome_page_disclaimer_title": {
+        "description": "Title for the disclaimer section on the hearing test welcome page."
+    },
+    "@hearing_test_welcome_page_disclaimer": {
+        "description": "Disclaimer text explaining the limitations and intended use of the hearing test module."
+    },
+
 
     "hearing_test_delete_alert_title": "Delete Result",
     "hearing_test_delete_alert_message": "Are you sure you want to permanently delete this result? This action cannot be undone.",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -114,6 +114,8 @@
     "hearing_test_welcome_page_welcome": "Witamy w teście słuchu",
     "hearing_test_welcome_page_description": "Ten moduł przetestuje Twój słuch w różnych częstotliwościach.",
     "hearing_test_welcome_page_start_hearing_test": "Rozpocznij test",
+    "hearing_test_welcome_page_disclaimer_title": "Zastrzeżenie",
+    "hearing_test_welcome_page_disclaimer": "To nie jest produkt medyczny. Przeznaczony jest wyłącznie do używania ze słuchawkami Sony WH-1000XM5, z włączoną redukcją szumów i ustawioną maksymalną głośnością, bez użycia korektora dźwięku.",
 
     "hearing_test_delete_alert_title": "Usuń wynik",
     "hearing_test_delete_alert_message": "Czy na pewno chcesz trwale usunąć ten wynik? Tej operacji nie można cofnąć.",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -113,6 +113,8 @@
 	"hearing_test_welcome_page_welcome": "Ласкаво просимо до тесту слуху",
 	"hearing_test_welcome_page_description": "Цей модуль протестує ваш слух на різних частотах.",
 	"hearing_test_welcome_page_start_hearing_test": "Почати тест",
+	"hearing_test_welcome_page_disclaimer_title": "застереження",
+    "hearing_test_welcome_page_disclaimer": "Це не є медичним виробом. Призначено лише для використання з навушниками Sony WH-1000XM5, з увімкненим шумозаглушенням та максимальною гучністю, без використання еквалайзера.",
 
 	"hearing_test_delete_alert_title": "Видалити результат",
 	"hearing_test_delete_alert_message": "Ви впевнені, що хочете остаточно видалити цей результат? Цю дію не можна скасувати.",

--- a/lib/modules/hearing_test/blocs/hearing_test/hearing_test_bloc.dart
+++ b/lib/modules/hearing_test/blocs/hearing_test/hearing_test_bloc.dart
@@ -45,6 +45,7 @@ class HearingTestBloc extends Bloc<HearingTestEvent, HearingTestState> {
     on<HearingTestStartMaskedTest>(_onStartMaskedTest);
     on<HearingTestPlayingMaskedSound>(_onPlayingMaskedSound);
     on<HearingTestNextMaskedFrequency>(_onNextMaskedFrequency);
+    on<HearingTestDisclaimerShown>(_onDisclaimerShown);
     // DEBUG
     on<HearingTestDebugEarLeftPartial>(_onDebugEarLeftPartial);
     on<HearingTestDebugEarRightPartial>(_onDebugEarRightPartial);
@@ -421,6 +422,13 @@ class HearingTestBloc extends Bloc<HearingTestEvent, HearingTestState> {
     );
 
     add(HearingTestPlayingMaskedSound());
+  }
+
+  void _onDisclaimerShown(
+    HearingTestDisclaimerShown event,
+    Emitter<HearingTestState> emit,
+  ) {
+    emit(state.copyWith(disclaimerShown: true));
   }
 
   // DEBUG

--- a/lib/modules/hearing_test/blocs/hearing_test/hearing_test_event.dart
+++ b/lib/modules/hearing_test/blocs/hearing_test/hearing_test_event.dart
@@ -25,6 +25,8 @@ class HearingTestNextMaskedFrequency extends HearingTestEvent {}
 
 class HearingTestStartMaskedTest extends HearingTestEvent {}
 
+class HearingTestDisclaimerShown extends HearingTestEvent {}
+
 // DEBUG
 
 class HearingTestDebugEarLeftPartial extends HearingTestEvent {}

--- a/lib/modules/hearing_test/blocs/hearing_test/hearing_test_state.dart
+++ b/lib/modules/hearing_test/blocs/hearing_test/hearing_test_state.dart
@@ -20,6 +20,8 @@ class HearingTestState {
   final bool isLoadingAudiogramClassificationResults;
   final String audiogramClassification;
 
+  final bool disclaimerShown;
+
   HearingTestState({
     this.isButtonPressed = false,
     this.wasSoundHeard = false,
@@ -35,6 +37,7 @@ class HearingTestState {
     this.maskedHeardCount = 0,
     this.isLoadingAudiogramClassificationResults = false,
     this.audiogramClassification = "",
+    this.disclaimerShown = false,
     HearingTestResult? results,
   }) : results = results ?? HearingTestResult.empty;
   HearingTestState copyWith({
@@ -53,6 +56,7 @@ class HearingTestState {
     int? maskedHeardCount,
     bool? isLoadingAudiogramClassificationResults,
     String? audiogramClassification,
+    bool? disclaimerShown,
   }) {
     return HearingTestState(
       isButtonPressed: isButtonPressed ?? this.isButtonPressed,
@@ -77,6 +81,7 @@ class HearingTestState {
           this.isLoadingAudiogramClassificationResults,
       audiogramClassification:
           audiogramClassification ?? this.audiogramClassification,
+      disclaimerShown: disclaimerShown ?? this.disclaimerShown,
     );
   }
 }

--- a/lib/modules/hearing_test/screens/hearing_test_welcome_page/hearing_test_welcome_page.dart
+++ b/lib/modules/hearing_test/screens/hearing_test_welcome_page/hearing_test_welcome_page.dart
@@ -8,6 +8,39 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hear_mate_app/modules/hearing_test/blocs/hearing_test/hearing_test_bloc.dart';
 
+void showDisclaimerDialog(BuildContext context) {
+  final l10n = AppLocalizations.of(context)!;
+  final bloc = context.read<HearingTestBloc>();
+
+  showDialog(
+    context: context,
+    barrierDismissible: false,
+    builder: (context) => AlertDialog(
+      title: Text(l10n.hearing_test_welcome_page_disclaimer_title),
+      content: Text(
+        l10n.hearing_test_welcome_page_disclaimer
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+            bloc.add(HearingTestStartTest());
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => BlocProvider.value(
+                  value: bloc,
+                  child: const HearingTestPage(),
+                ),
+              ),
+            );
+          },
+          child: const Text('OK'),
+        ),
+      ],
+    ),
+  );
+}
+
 class HearingTestWelcomePage extends StatelessWidget {
   const HearingTestWelcomePage({super.key});
 
@@ -47,67 +80,81 @@ class HearingTestWelcomePageView extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
 
-    return Scaffold(
-      appBar: HMAppBar(
-        title: l10n.hearing_test_welcome_page_title,
-        route: ModalRoute.of(context)?.settings.name ?? "",
-      ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(20.0),
-              child: Text(
-                l10n.hearing_test_welcome_page_welcome,
-                style: const TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
+    return BlocListener<HearingTestBloc, HearingTestState>(
+      listenWhen: (previous, current) => 
+          !previous.disclaimerShown && !current.disclaimerShown,
+      listener: (context, state) {
+        if (!state.disclaimerShown) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            context.read<HearingTestBloc>().add(HearingTestDisclaimerShown());
+          });
+        }
+      },
+      child: Scaffold(
+        appBar: HMAppBar(
+          title: l10n.hearing_test_welcome_page_title,
+          route: ModalRoute.of(context)?.settings.name ?? "",
+        ),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(20.0),
+                child: Text(
+                  l10n.hearing_test_welcome_page_welcome,
+                  style: const TextStyle(
+                    fontSize: 28,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
                 ),
-                textAlign: TextAlign.center,
               ),
-            ),
-            const SizedBox(height: 20),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 30),
-              child: Text(
-                l10n.hearing_test_welcome_page_description,
-                style: const TextStyle(fontSize: 18, color: Colors.grey),
-                textAlign: TextAlign.center,
+              const SizedBox(height: 20),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 30),
+                child: Text(
+                  l10n.hearing_test_welcome_page_description,
+                  style: const TextStyle(fontSize: 18, color: Colors.grey),
+                  textAlign: TextAlign.center,
+                ),
               ),
-            ),
-            const SizedBox(height: 40),
-            FilledButton(
-              onPressed: () {
-                context.read<HearingTestBloc>().add(HearingTestStartTest());
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder:
-                        (_) => BlocProvider.value(
+              const SizedBox(height: 40),
+              FilledButton(
+                onPressed: () {
+                  if (context.read<HearingTestBloc>().state.disclaimerShown) {
+                    context.read<HearingTestBloc>().add(HearingTestStartTest());
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => BlocProvider.value(
                           value: context.read<HearingTestBloc>(),
                           child: const HearingTestPage(),
                         ),
-                  ),
-                );
-              },
-              child: Text(l10n.hearing_test_welcome_page_start_hearing_test),
-            ),
-            const SizedBox(height: 10),
-            OutlinedButton(
-              onPressed: () {
-                Navigator.of(context).push(
-                  MaterialPageRoute(
-                    builder:
-                        (_) => BlocProvider.value(
-                          value: context.read<HearingTestBloc>(),
-                          child: const HearingTestHistoryResultsPage(),
-                        ),
-                  ),
-                );
-              },
-              child: Text(l10n.hearing_test_result_history_page),
-            ),
-          ],
+                      ),
+                    );
+                  } else {
+                    showDisclaimerDialog(context);
+                  }
+                },
+                child: Text(l10n.hearing_test_welcome_page_start_hearing_test),
+              ),
+              const SizedBox(height: 10),
+              OutlinedButton(
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder:
+                          (_) => BlocProvider.value(
+                            value: context.read<HearingTestBloc>(),
+                            child: const HearingTestHistoryResultsPage(),
+                          ),
+                    ),
+                  );
+                },
+                child: Text(l10n.hearing_test_result_history_page),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
This PR introduces a disclaimer dialog that is shown to the user before starting their first hearing test. The disclaimer informs users that the app is not a medical grade product and is intended to be used only with Sony WH-1000XM5 headphones, with noise cancelling turned on, volume set to maximum, and without using an equalizer.

<img width="1247" height="670" alt="image" src="https://github.com/user-attachments/assets/3013980d-eba2-4c40-b3cf-23001c5808aa" />

Closes #82 