### PR TITLE
Sg/test logic and calibtation fixes

### DIFF
--- a/lib/features/hearing_test/bloc/hearing_test_state.dart
+++ b/lib/features/hearing_test/bloc/hearing_test_state.dart
@@ -33,7 +33,7 @@ class HearingTestState {
     this.isMaskingStarted = false,
     this.currentFrequencyIndex = 0,
     this.currentMaskingDBLevel = 0,
-    this.currentDBLevel = 20,
+    this.currentDBLevel = 30,
     this.dbLevelToHearCountMap = const {},
     this.frequenciesThatRequireMasking,
     this.maskedHeardCount = 0,


### PR DESCRIPTION
i promise this is last time i modify this logic
This pr implements correctly the Hughson–Westlake method. It is almost the same what Dominika said but the step up is 10 dB and step down is still 5 dB. This method is mentioned in publications whereas Dominikas method is not. You could say that what we used before was a modified Hughson–Westlake method but i would stick to what can be found in books and papers. This way the test is faster.

Also:
- refactor how the hits and misses are counted on different dB levels on same freq
- got rid of obsolete code in HL to SPL mapping (as i now much smarter and more aware how it worsk then i was before 🕺)